### PR TITLE
Support for proto and libprotobuf

### DIFF
--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -2,6 +2,11 @@
 import json
 import os
 
+class SdkTarget(object):
+    def __init__(self, sdk, cxx, protoc):
+        self.sdk = sdk
+        self.cxx = cxx
+        self.protoc = protoc
 
 class SdkHelpers(object):
     def __init__(self):
@@ -38,7 +43,14 @@ class SdkHelpers(object):
 
             for cxx in cxx_list:
                 if SdkHelpers.shouldBuildSdk(sdk, cxx):
-                    self.sdk_targets += [(sdk, cxx)]
+                    protoc = None
+                    rel_protoc_path = sdk[cxx.target.platform].get('protoc_path', None)
+                    if rel_protoc_path:
+                        protoc_path = os.path.join(sdk['path'], rel_protoc_path)
+                        protoc = builder.DetectProtoc(path = protoc_path)
+                        for path in sdk['include_paths']:
+                            protoc.includes += [os.path.join(sdk['path'], path)]
+                    self.sdk_targets += [SdkTarget(sdk, cxx, protoc)]
 
         if 'present' in sdk_list:
             for sdk in not_found:
@@ -159,12 +171,10 @@ class SdkHelpers(object):
             cxx.cxxincludes += [os.path.join(sdk['path'], path)]
 
         # Link steps.
-        lib_folder = sdk[cxx.target.platform][cxx.target.arch]['lib_folder']
-        lib_folder = os.path.join(sdk['path'], lib_folder)
         for lib in SdkHelpers.getLists(sdk, 'libs', cxx):
-            cxx.linkflags += [os.path.join(sdk['path'], lib_folder, lib)]
+            cxx.linkflags += [os.path.join(sdk['path'], lib)]
         for lib in SdkHelpers.getLists(sdk, 'postlink_libs', cxx):
-            cxx.postlink += [os.path.join(sdk['path'], lib_folder, lib)]
+            cxx.postlink += [os.path.join(sdk['path'], lib)]
 
         if cxx.target.platform == 'linux':
             cxx.linkflags[0:0] = ['-lm']
@@ -173,14 +183,15 @@ class SdkHelpers(object):
 
         dynamic_libs = SdkHelpers.getLists(sdk, 'dynamic_libs', cxx)
         for library in dynamic_libs:
-            source_path = os.path.join(lib_folder, library)
-            output_path = os.path.join(binary.localFolder, library)
+            file_name = os.path.split(library)[1]
+            source_path = os.path.join(sdk['path'], library)
+            output_path = os.path.join(binary.localFolder, file_name)
 
             context.AddFolder(binary.localFolder)
             output = context.AddSymlink(source_path, output_path)
 
             cxx.weaklinkdeps += [output]
-            cxx.linkflags[0:0] = [library]
+            cxx.linkflags[0:0] = [file_name]
 
         if cxx.target.platform == 'linux':
             if sdk[cxx.target.platform]['uses_system_cxxlib']:

--- a/manifests/bgt.json
+++ b/manifests/bgt.json
@@ -23,12 +23,11 @@
     ],
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }        
     }
 }

--- a/manifests/blade.json
+++ b/manifests/blade.json
@@ -38,13 +38,12 @@
     "linux": {
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/linux64/tier1.a",
+                "lib/linux64/interfaces.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0.so",
-                "libvstdlib.so"
+                "lib/linux64/libtier0.so",
+                "lib/linux64/libvstdlib.so"
             ]
         },
         "defines": [
@@ -54,23 +53,23 @@
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/interfaces.lib"
+            ]
         },
         "x86_64": {
-            "lib_folder": "lib/public/win64"
+            "libs": [
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/vstdlib.lib",
+                "lib/public/win64/interfaces.lib"
+            ]
         },
         "defines": [
             "_GLIBCXX_USE_CXX11_ABI=0"
-        ],
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib",
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
         ]
     }
 }

--- a/manifests/bms.json
+++ b/manifests/bms.json
@@ -31,26 +31,24 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1.a",
-                "mathlib.a"
+                "lib/public/linux32/tier1.a",
+                "lib/public/linux32/mathlib.a"
             ],
-            "lib_folder": "lib/public/linux32",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/public/linux32/libtier0_srv.so",
+                "lib/public/linux32/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "mathlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/mathlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/contagion.json
+++ b/manifests/contagion.json
@@ -27,12 +27,11 @@
     ],
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/cs2.json
+++ b/manifests/cs2.json
@@ -14,6 +14,7 @@
     },
     "source2": true,
     "include_paths": [
+        "thirdparty/protobuf-3.21.8/src",
         "public",
         "public/engine",
         "public/mathlib",
@@ -27,24 +28,26 @@
     "linux": {
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/linux64/tier1.a",
+                "lib/linux64/interfaces.a",
+                "lib/linux64/release/libprotobuf.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0.so"
+                "lib/linux64/libtier0.so"
             ]
         },
-        "uses_system_cxxlib": true
+        "uses_system_cxxlib": true,
+        "protoc_path": "devtools/bin/linux/protoc"
     },
     "windows": {
         "x86_64": {
-            "lib_folder": "lib/public/win64"
+            "libs": [
+                "lib/public/win64/2015/libprotobuf.lib",
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/interfaces.lib"
+            ]
         },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "interfaces.lib"
-        ]
+        "protoc_path": "devtools/bin/protoc.exe"
     }
 }

--- a/manifests/csgo.json
+++ b/manifests/csgo.json
@@ -42,24 +42,22 @@
     "linux": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a",
-                "interfaces_i486.a"
+                "lib/linux/tier1_i486.a",
+                "lib/linux/interfaces_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0.so",
-                "libvstdlib.so"
+                "lib/linux/libtier0.so",
+                "lib/linux/libvstdlib.so"
             ]
         },
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/linux64/tier1.a",
+                "lib/linux64/interfaces.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0_client.so",
-                "libvstdlib_client.so"
+                "lib/linux64/libtier0_client.so",
+                "lib/linux64/libvstdlib_client.so"
             ]
         },
         "defines": [
@@ -70,13 +68,12 @@
     "mac": {
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/osx64/tier1.a",
+                "lib/osx64/interfaces.a"
             ],
-            "lib_folder": "lib/osx64",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/osx64/libtier0.dylib",
+                "lib/osx64/libvstdlib.dylib"
             ]
         },
         "defines": [
@@ -86,16 +83,15 @@
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/interfaces.lib"
+            ]
         },
         "defines": [
             "_GLIBCXX_USE_CXX11_ABI=0"
-        ],
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
         ]
     }
 }

--- a/manifests/css.json
+++ b/manifests/css.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/darkm.json
+++ b/manifests/darkm.json
@@ -25,12 +25,11 @@
     ],
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/dods.json
+++ b/manifests/dods.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/doi.json
+++ b/manifests/doi.json
@@ -33,13 +33,12 @@
     "linux": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a",
-                "interfaces_i486.a"
+                "lib/linux/tier1_i486.a",
+                "lib/linux/interfaces_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -47,26 +46,24 @@
     "mac": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a",
-                "interfaces_i486.a"
+                "lib/mac/tier1_i486.a",
+                "lib/mac/interfaces_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/interfaces.lib"
+            ]
+        }
     }
 }

--- a/manifests/dota.json
+++ b/manifests/dota.json
@@ -27,24 +27,22 @@
     "linux": {
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/linux64/tier1.a",
+                "lib/linux64/interfaces.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0.so"
+                "lib/linux64/libtier0.so"
             ]
         },
         "uses_system_cxxlib": true
     },
     "windows": {
         "x86_64": {
-            "lib_folder": "lib/public/win64"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "interfaces.lib"
-        ]
+            "libs": [
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/interfaces.lib"
+            ]
+        }
     }
 }

--- a/manifests/episode1.json
+++ b/manifests/episode1.json
@@ -29,24 +29,22 @@
     "linux": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "linux_sdk/tier1_i486.a"
             ],
-            "lib_folder": "linux_sdk",
             "dynamic_libs": [
-                "tier0_i486.so",
-                "vstdlib_i486.so"
+                "linux_sdk/tier0_i486.so",
+                "linux_sdk/vstdlib_i486.so"
             ]
         },
         "uses_system_cxxlib": false
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/eye.json
+++ b/manifests/eye.json
@@ -26,12 +26,11 @@
     ],
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/hl2dm.json
+++ b/manifests/hl2dm.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/insurgency.json
+++ b/manifests/insurgency.json
@@ -35,13 +35,12 @@
     "linux": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a",
-                "interfaces_i486.a"
+                "lib/linux/tier1_i486.a",
+                "lib/linux/interfaces_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -49,44 +48,42 @@
     "mac": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a",
-                "interfaces_i486.a"
+                "lib/mac/tier1_i486.a",
+                "lib/mac/interfaces_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "x86_64": {
             "postlink_libs": [
-                "tier1.a",
-                "interfaces.a"
+                "lib/osx64/tier1.a",
+                "lib/osx64/interfaces.a"
             ],
-            "lib_folder": "lib/osx64",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/osx64/libtier0.dylib",
+                "lib/osx64/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/interfaces.lib"
+            ]
         },
         "x86_64": {
-            "lib_folder": "lib/public/win64"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib",
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
-        ]
+            "libs": [
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/vstdlib.lib",
+                "lib/public/win64/interfaces.lib"
+            ]
+        }
     }
 }

--- a/manifests/l4d.json
+++ b/manifests/l4d.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0.so",
-                "libvstdlib.so"
+                "lib/linux/libtier0.so",
+                "lib/linux/libvstdlib.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/l4d2.json
+++ b/manifests/l4d2.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/mcv.json
+++ b/manifests/mcv.json
@@ -30,26 +30,24 @@
     "linux": {
         "x86_64": {
             "postlink_libs": [
-                "interfaces.a",
-                "tier1.a"
+                "lib/linux64/interfaces.a",
+                "lib/linux64/tier1.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0.so",
-                "libvstdlib.so"
+                "lib/linux64/libtier0.so",
+                "lib/linux64/libvstdlib.so"
             ]
         },
         "uses_system_cxxlib": false
     },
     "windows": {
         "x86_64": {
-            "lib_folder": "lib/public/win64"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
-        ]
+            "libs": [
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/vstdlib.lib",
+                "lib/public/win64/interfaces.lib"
+            ]
+        }
     }
 }

--- a/manifests/mock.json
+++ b/manifests/mock.json
@@ -35,22 +35,20 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "tier0_i486.so",
-                "vstdlib_i486.so"
+                "lib/linux/tier0_i486.so",
+                "lib/linux/vstdlib_i486.so"
             ]
         },
         "x86_64": {
             "postlink_libs": [
-                "tier1.a"
+                "lib/linux64/tier1.a"
             ],
-            "lib_folder": "lib/linux64",
             "dynamic_libs": [
-                "libtier0_client.so",
-                "libvstdlib_client.so"
+                "lib/linux64/libtier0_client.so",
+                "lib/linux64/libvstdlib_client.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -58,30 +56,29 @@
     "mac": {
         "x86_64": {
             "postlink_libs": [
-                "tier1.a"
+                "lib/osx64/tier1.a"
             ],
-            "lib_folder": "lib/osx64",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/osx64/libtier0.dylib",
+                "lib/osx64/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
         },
         "x86_64": {
-            "lib_folder": "lib/public/win64"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/nucleardawn.json
+++ b/manifests/nucleardawn.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/orangebox.json
+++ b/manifests/orangebox.json
@@ -27,24 +27,22 @@
     "linux": {
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "tier0_i486.so",
-                "vstdlib_i486.so"
+                "lib/linux/tier0_i486.so",
+                "lib/linux/vstdlib_i486.so"
             ]
         },
         "uses_system_cxxlib": false
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/pvkii.json
+++ b/manifests/pvkii.json
@@ -34,12 +34,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1.a"
+                "lib/public/linux32/tier1.a"
             ],
-            "lib_folder": "lib/public/linux32",
             "dynamic_libs": [
-                "libtier0.so",
-                "libvstdlib.so"
+                "lib/public/linux32/libtier0.so",
+                "lib/public/linux32/libvstdlib.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -53,12 +52,11 @@
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/sdk2013.json
+++ b/manifests/sdk2013.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1.a"
+                "lib/public/linux32/tier1.a"
             ],
-            "lib_folder": "lib/public/linux32",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/public/linux32/libtier0_srv.so",
+                "lib/public/linux32/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1.a"
+                "lib/public/osx32/tier1.a"
             ],
-            "lib_folder": "lib/public/osx32",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/public/osx32/libtier0.dylib",
+                "lib/public/osx32/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }

--- a/manifests/swarm.json
+++ b/manifests/swarm.json
@@ -26,13 +26,12 @@
     ],
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib",
-            "interfaces.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib",
+                "lib/public/interfaces.lib"
+            ]
+        }
     }
 }

--- a/manifests/tf2.json
+++ b/manifests/tf2.json
@@ -37,12 +37,11 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/linux/tier1_i486.a"
             ],
-            "lib_folder": "lib/linux",
             "dynamic_libs": [
-                "libtier0_srv.so",
-                "libvstdlib_srv.so"
+                "lib/linux/libtier0_srv.so",
+                "lib/linux/libvstdlib_srv.so"
             ]
         },
         "uses_system_cxxlib": false
@@ -54,24 +53,22 @@
         ],
         "x86": {
             "postlink_libs": [
-                "tier1_i486.a"
+                "lib/mac/tier1_i486.a"
             ],
-            "lib_folder": "lib/mac",
             "dynamic_libs": [
-                "libtier0.dylib",
-                "libvstdlib.dylib"
+                "lib/mac/libtier0.dylib",
+                "lib/mac/libvstdlib.dylib"
             ]
         },
         "cxxlib": "c++"
     },
     "windows": {
         "x86": {
-            "lib_folder": "lib/public"
-        },
-        "libs": [
-            "tier0.lib",
-            "tier1.lib",
-            "vstdlib.lib"
-        ]
+            "libs": [
+                "lib/public/tier0.lib",
+                "lib/public/tier1.lib",
+                "lib/public/vstdlib.lib"
+            ]
+        }
     }
 }


### PR DESCRIPTION
libprotobuf lives in a different library folder in most SDKs, so support for defining a single `lib_folder` for all platforms was removed. Manifests have been updated accordingly, along with adding libprotobuf for `cs2`.

Additionally, support has been added to generate a ProtoTool instance from a platform's `proto_path`.