### PR TITLE
Fix HL2SDK manifests lookup

### DIFF
--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -119,8 +119,7 @@ class SdkHelpers(object):
 
     @staticmethod
     def getSdks(builder):
-        sdk_manifest_dir = os.path.join(builder.sourcePath, 'hl2sdk-manifests',
-                                        'manifests')
+        sdk_manifest_dir = os.path.join(builder.options.hl2sdk_manifests, 'manifests')
 
         out = []
         for sdk_manifest in os.listdir(sdk_manifest_dir):


### PR DESCRIPTION
POV: tried to build a project copied from [s2_sample_mm project](https://github.com/alliedmodders/metamod-source/tree/36b9858a11ba45ab95121c916987507141ceebee/samples/s2_sample_mm)

Issue: it tried to look up manifests in the project folder, no matter what's specified in `--hl2sdk-manifests`.
```bash
Traceback (most recent call last):
  File "C:\Users\ak\AppData\Local\Programs\Python\Python310\lib\site-packages\ambuild2\frontend\v2_2\prep.py", line 156, in Configure
    if not cm.generate(options.generator):
  File "C:\Users\ak\AppData\Local\Programs\Python\Python310\lib\site-packages\ambuild2\frontend\context_manager.py", line 93, in generate
    self.parseBuildScripts()
  File "C:\Users\ak\AppData\Local\Programs\Python\Python310\lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 50, in parseBuildScripts
    self.execContext(cx)
  File "C:\Users\ak\AppData\Local\Programs\Python\Python310\lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 148, in execContext
    exec(code, scriptGlobals)
  File "D:\dev\csgo\whitelist\AMBuildScript", line 296, in <module>
    MMSPlugin.detectSDKs()
  File "D:\dev\csgo\whitelist\AMBuildScript", line 114, in detectSDKs
    SdkHelpers.findSdks(builder, self.all_targets, sdk_list)
  File "D:\dev\csgo\metamod-source\hl2sdk-manifests\SdkHelpers.ambuild", line 23, in findSdks
    for sdk_name, sdk in SdkHelpers.getSdks(builder):
  File "D:\dev\csgo\metamod-source\hl2sdk-manifests\SdkHelpers.ambuild", line 126, in getSdks
    for sdk_manifest in os.listdir(sdk_manifest_dir):
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'D:\\dev\\csgo\\whitelist\\hl2sdk-manifests\\manifests'
Configure failed: [WinError 3] The system cannot find the path specified: 'D:\\dev\\csgo\\whitelist\\hl2sdk-manifests\\manifests'
```