### PR TITLE
Add few common include paths for CS2

### DIFF
--- a/manifests/cs2.json
+++ b/manifests/cs2.json
@@ -21,8 +21,10 @@
         "public/vstdlib",
         "public/tier0",
         "public/tier1",
+        "public/entity2",
         "public/game/server",
         "game/shared",
+        "game/server",
         "common"
     ],
     "linux": {


### PR DESCRIPTION
These includes are necessary if you want to use any of the entity related stuff in the hl2sdk-cs2, and are very common to use.