### PR TITLE
Enable 64bits compilation for windows

### DIFF
--- a/manifests/tf2.json
+++ b/manifests/tf2.json
@@ -9,7 +9,8 @@
     },
     "platforms": {
         "windows": [
-            "x86"
+            "x86",
+            "x86_64"
         ],
         "linux": [
             "x86",
@@ -83,6 +84,14 @@
                 "lib/public/tier0.lib",
                 "lib/public/tier1.lib",
                 "lib/public/vstdlib.lib"
+            ]
+        },
+        "x86_64": {
+            "libs": [
+                "lib/public/x64/mathlib.lib",
+                "lib/public/x64/tier1.lib",
+                "lib/public/x64/tier0.lib",
+                "lib/public/x64/vstdlib.lib"
             ]
         }
     }

--- a/manifests/tf2.json
+++ b/manifests/tf2.json
@@ -88,10 +88,10 @@
         },
         "x86_64": {
             "libs": [
-                "lib/public/x64/mathlib.lib",
-                "lib/public/x64/tier1.lib",
-                "lib/public/x64/tier0.lib",
-                "lib/public/x64/vstdlib.lib"
+                "lib/public/win64/mathlib.lib",
+                "lib/public/win64/tier1.lib",
+                "lib/public/win64/tier0.lib",
+                "lib/public/win64/vstdlib.lib"
             ]
         }
     }


### PR DESCRIPTION
Hopefully the naming for the libs will be correct. Looks like that's what the contractor opted for as well.