### PR TITLE
Fix building only against available sdks

### DIFF
--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -69,7 +69,7 @@ class SdkHelpers(object):
             return sdk_name != 'mock'
         if sdk_name in sdk_list:
             return True
-        return 'present' in sdk_list
+        return 'present' not in sdk_list
 
     def shouldFindSdk(self, sdk, sdk_list):
         # Remove SDKs that the project doesn't support.


### PR DESCRIPTION
`--sdks present` is supposed to ignore missing hl2sdks but still failed if one was missing.

This came up when configuring sourcemod

```
PS C:\Users\Jannik\Documents\GitHub\sourcemod\build> python ..\configure.py --enable-optimize --mysql-path=C:\Users\Jannik\Documents\GitHub\mysql-5.5 -s present
Checking CC compiler (vendor test msvc)... ['C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX64\\x86\\cl.exe', 'test.c', '-o', 'test-c.exe', '-nologo', '-showIncludes']
found msvc version 1937, x86
Checking CXX compiler (vendor test msvc)... ['C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX64\\x86\\cl.exe', 'test.cpp', '-o', 'test-cxx.exe', '-nologo', '-showIncludes']
found msvc version 1937, x86
Traceback (most recent call last):
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\v2_2\prep.py", line 156, in Configure
    if not cm.generate(options.generator):
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\context_manager.py", line 93, in generate
    self.parseBuildScripts()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 50, in parseBuildScripts
    self.execContext(cx)
    ~~~~~~~~~~~~~~~~^^^^
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 149, in execContext
    exec(code, scriptGlobals)
    ~~~~^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Jannik\Documents\GitHub\sourcemod\AMBuildScript", line 567, in <module>
    SM.detectSDKs()
    ~~~~~~~~~~~~~^^
  File "C:\Users\Jannik\Documents\GitHub\sourcemod\AMBuildScript", line 122, in detectSDKs
    SdkHelpers.findSdks(builder, self.all_targets, sdk_list)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Jannik\Documents\GitHub\sourcemod\hl2sdk-manifests\SdkHelpers.ambuild", line 35, in findSdks
    raise Exception('Could not find a valid path for {0}'.format(sdk_name))
Exception: Could not find a valid path for bgt
Configure failed: Could not find a valid path for bgt
```

It should look like this after this change:

```
PS C:\Users\Jannik\Documents\GitHub\sourcemod\build> python ..\configure.py --enable-optimize --mysql-path=C:\Users\Jannik\Documents\GitHub\mysql-5.5 -s present
Checking CC compiler (vendor test msvc)... ['C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX64\\x86\\cl.exe', 'test.c', '-o', 'test-c.exe', '-nologo', '-showIncludes']
found msvc version 1937, x86
Checking CXX compiler (vendor test msvc)... ['C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX64\\x86\\cl.exe', 'test.cpp', '-o', 'test-cxx.exe', '-nologo', '-showIncludes']
found msvc version 1937, x86
Warning: hl2sdk-bgt was not found, and will not be included in build.
Warning: hl2sdk-blade was not found, and will not be included in build.
Warning: hl2sdk-bms was not found, and will not be included in build.
Warning: hl2sdk-contagion was not found, and will not be included in build.
Warning: hl2sdk-css was not found, and will not be included in build.
Warning: hl2sdk-darkm was not found, and will not be included in build.
Warning: hl2sdk-dods was not found, and will not be included in build.
Warning: hl2sdk-doi was not found, and will not be included in build.
Warning: hl2sdk-episode1 was not found, and will not be included in build.
Warning: hl2sdk-eye was not found, and will not be included in build.
Warning: hl2sdk-hl2dm was not found, and will not be included in build.
Warning: hl2sdk-insurgency was not found, and will not be included in build.
Warning: hl2sdk-l4d was not found, and will not be included in build.
Warning: hl2sdk-l4d2 was not found, and will not be included in build.
Warning: hl2sdk-mock was not found, and will not be included in build.
Warning: hl2sdk-nucleardawn was not found, and will not be included in build.
Warning: hl2sdk-orangebox was not found, and will not be included in build.
Warning: hl2sdk-pvkii was not found, and will not be included in build.
Warning: hl2sdk-sdk2013 was not found, and will not be included in build.
Warning: hl2sdk-swarm was not found, and will not be included in build.
Warning: hl2sdk-tf2 was not found, and will not be included in build.
```