### PR TITLE
Remove vstdlib include_paths for cs2, dota, deadlock

### DIFF
--- a/manifests/cs2.json
+++ b/manifests/cs2.json
@@ -18,7 +18,6 @@
         "public",
         "public/engine",
         "public/mathlib",
-        "public/vstdlib",
         "public/tier0",
         "public/tier1",
         "public/entity2",

--- a/manifests/deadlock.json
+++ b/manifests/deadlock.json
@@ -15,7 +15,6 @@
         "public",
         "public/engine",
         "public/mathlib",
-        "public/vstdlib",
         "public/tier0",
         "public/tier1",
         "public/entity2",

--- a/manifests/dota.json
+++ b/manifests/dota.json
@@ -18,7 +18,6 @@
         "public",
         "public/engine",
         "public/mathlib",
-        "public/vstdlib",
         "public/tier0",
         "public/tier1",
         "public/entity2",


### PR DESCRIPTION
`public/vstdlib` does not exist on cs2 and dota branches since https://github.com/alliedmodders/hl2sdk/commit/64f3cac5e905fad42dc90fe2f9beb615539650ca resulting in warnings when building, e.g., cs2kz-metamod:
```
C:\Users\daric\dev\cs2kz-metamod\hl2sdk-cs2\public/vstdlib: warning: directory does not exist.
```

cc @GAMMACASE 