### PR TITLE
Build tier1 & mathlib for tf2

### DIFF
--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -48,6 +48,9 @@ class SdkTarget(object):
 
     @staticmethod
     def findLibrary(context, sdk, cxx, name):
+        # Mock libs are currently unhandled (different ambuild scripts)
+        if sdk['name'] == 'mock':
+            return None
         cxx = cxx.clone()
         SdkHelpers.configureCxx(context, cxx, sdk)
         ambuilder = os.path.join(sdk['path'], name, 'AMBuilder')
@@ -214,9 +217,9 @@ class SdkHelpers(object):
         if cxx.family == 'msvc':
             cxx.defines += ['COMPILER_MSVC']
             if cxx.target.arch == 'x86':
-                cxx.defines += ['COMPILER_MSVC32']
+                cxx.defines += ['COMPILER_MSVC32', 'WIN32']
             elif cxx.target.arch == 'x86_64':
-                cxx.defines += ['COMPILER_MSVC64']
+                cxx.defines += ['COMPILER_MSVC64', 'WIN32', 'WIN64']
 
             if cxx.version >= 1900:
                 cxx.linkflags += ['legacy_stdio_definitions.lib']

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -7,16 +7,17 @@ def get_this_file_path():
 
 class SdkLibBuilder(object):
     def __init__(self, sdk, name, cxx):
-        self.targets = [cxx]
+        self.targets = [cxx.clone()]
         self.libs = []
-        self.sdk_name = sdk['name']
+        self.sdk = sdk
         self.name = name
     def ConfigureLibrary(self, project, compiler, context, prefix = ''):
         name = prefix + project.name
-        binary = project.Configure(compiler, '{0}_{1}'.format(self.sdk_name, name), '{0} - {1} - {2}'.format(self.sdk_name, self.name, compiler.target.arch))
+        binary = project.Configure(compiler, '{0}_{1}'.format(self.sdk['name'], name), '{0} - {1} - {2}'.format(self.sdk['name'], self.name, compiler.target.arch))
         binary.compiler.cxxincludes += [
             os.path.join(context.currentSourcePath)
         ]
+        SdkHelpers.configureCxx(context, binary, self.sdk)
         return binary
 
 
@@ -51,8 +52,6 @@ class SdkTarget(object):
         # Mock libs are currently unhandled (different ambuild scripts)
         if sdk['name'] == 'mock':
             return None
-        cxx = cxx.clone()
-        SdkHelpers.configureCxx(context, cxx, sdk)
         ambuilder = os.path.join(sdk['path'], name, 'AMBuilder')
         if os.path.exists(ambuilder):
             ambuilder = os.path.abspath(ambuilder)
@@ -196,7 +195,9 @@ class SdkHelpers(object):
             binary.compiler.linkdeps += [task.binary]
 
     @staticmethod
-    def configureCxx(context, cxx, sdk):
+    def configureCxx(context, binary, sdk):
+        cxx = binary.compiler
+
         # Includes/defines.
         cxx.defines += ['SOURCE_ENGINE={}'.format(sdk['code'])]
         cxx.defines += ['GAME_DLL', 'RAD_TELEMETRY_DISABLED']
@@ -238,10 +239,20 @@ class SdkHelpers(object):
         # Link steps.
         for lib in SdkHelpers.getLists(sdk, 'libs', cxx):
             cxx.linkflags += [os.path.join(sdk['path'], lib)]
-        for lib in SdkHelpers.getLists(sdk, 'dynamic_libs', cxx):
-            cxx.linkflags += [os.path.join(sdk['path'], lib)]
         for lib in SdkHelpers.getLists(sdk, 'postlink_libs', cxx):
             cxx.postlink += [os.path.join(sdk['path'], lib)]
+
+        dynamic_libs = SdkHelpers.getLists(sdk, 'dynamic_libs', cxx)
+        for library in dynamic_libs:
+            file_name = os.path.split(library)[1]
+            source_path = os.path.join(sdk['path'], library)
+            output_path = os.path.join(binary.localFolder, file_name)
+
+            context.AddFolder(binary.localFolder)
+            output = context.AddSymlink(source_path, output_path)
+
+            cxx.weaklinkdeps += [output]
+            cxx.linkflags[0:0] = [file_name]
 
         # cflags
         for cflag in SdkHelpers.getLists(sdk, 'cflags', cxx):

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -206,7 +206,10 @@ class SdkHelpers(object):
             ]
             for rm_define in rm_defines:
                 if rm_define in cxx.defines:
-                    cxx.defines.remove(rm_define)
+                    try:
+                        cxx.defines.remove(rm_define)
+                    except ValueError:
+                        pass
 
         if cxx.family == 'msvc':
             cxx.defines += ['COMPILER_MSVC']
@@ -246,7 +249,10 @@ class SdkHelpers(object):
 
         if cxx.target.platform == 'linux':
             if sdk[cxx.target.platform]['uses_system_cxxlib']:
-                cxx.linkflags.remove('-static-libstdc++')
+                try:
+                    cxx.linkflags.remove('-static-libstdc++')
+                except ValueError:
+                    pass
                 cxx.linkflags += ['-lstdc++']
 
         if 'tier1' in sdk and cxx.target.arch in sdk['tier1']:

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -56,7 +56,10 @@ class SdkTarget(object):
         if os.path.exists(ambuilder):
             ambuilder = os.path.abspath(ambuilder)
             libbuilders = SdkLibBuilder(sdk, name, cxx)
-            context.Build(os.path.relpath(ambuilder, context.sourcePath), { 'HL2SDK': libbuilders })
+            oldSource = context.cm.sourcePath
+            context.cm.sourcePath = os.path.dirname(ambuilder)
+            libcontext = context.Build('AMBuilder', { 'HL2SDK': libbuilders })
+            context.cm.sourcePath = oldSource
             if len(libbuilders.libs) != 1:
                 raise Exception('No lib found for {0}'.format(name))
             return libbuilders.libs[0]

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -9,12 +9,11 @@ class SdkLibBuilder(object):
     def __init__(self, sdk, name, cxx):
         self.targets = [cxx]
         self.libs = []
-        self.tag = '{0} - {1}'.format(sdk['name'], name)
+        self.sdk_name = sdk['name']
+        self.name = name
     def ConfigureLibrary(self, project, compiler, context, prefix = ''):
         name = prefix + project.name
-        if compiler.target.platform == 'linux' and compiler.target.arch == 'x86':
-            name += '_i486'
-        binary = project.Configure(compiler, name, '{0} - {1}'.format(self.tag, compiler.target.arch))
+        binary = project.Configure(compiler, '{0}_{1}'.format(self.sdk_name, name), '{0} - {1} - {2}'.format(self.sdk_name, self.name, compiler.target.arch))
         binary.compiler.cxxincludes += [
             os.path.join(context.currentSourcePath)
         ]

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -5,11 +5,61 @@ import os
 def get_this_file_path():
     return get_this_file_path.__code__.co_filename
 
+class SdkLibBuilder(object):
+    def __init__(self, sdk, name, cxx):
+        self.targets = [cxx]
+        self.libs = []
+        self.tag = '{0} - {1}'.format(sdk['name'], name)
+    def ConfigureLibrary(self, project, compiler, context, prefix = ''):
+        name = prefix + project.name
+        if compiler.target.platform == 'linux' and compiler.target.arch == 'x86':
+            name += '_i486'
+        binary = project.Configure(compiler, name, '{0} - {1}'.format(self.tag, compiler.target.arch))
+        binary.compiler.cxxincludes += [
+            os.path.join(context.currentSourcePath)
+        ]
+        return binary
+
+
 class SdkTarget(object):
-    def __init__(self, sdk, cxx, protoc):
+    def __init__(self, context, sdk, cxx):
         self.sdk = sdk
         self.cxx = cxx
-        self.protoc = protoc
+        # Find protoc
+        self.protoc = None
+        rel_protoc_path = sdk[cxx.target.platform].get('protoc_path', None)
+        if rel_protoc_path:
+            protoc_path = os.path.join(sdk['path'], rel_protoc_path)
+            self.protoc = builder.DetectProtoc(path = protoc_path)
+            for path in sdk['include_paths']:
+                protoc.includes += [os.path.join(sdk['path'], path)]
+        # Find tier1
+        tier1 = SdkTarget.findLibrary(context, sdk, cxx, 'tier1')
+        # Find mathlib
+        mathlib = SdkTarget.findLibrary(context, sdk, cxx, 'mathlib')
+
+        # Only append the libs at the end, so they aren't found during the configureCxx step
+        if not 'tier1' in sdk :
+            sdk['tier1'] = {}
+        if not 'mathlib' in sdk :
+            sdk['mathlib'] = {}
+        sdk['tier1'][cxx.target.arch] = tier1
+        sdk['mathlib'][cxx.target.arch] = mathlib
+
+
+    @staticmethod
+    def findLibrary(context, sdk, cxx, name):
+        cxx = cxx.clone()
+        SdkHelpers.configureCxx(context, cxx, sdk)
+        ambuilder = os.path.join(sdk['path'], name, 'AMBuilder')
+        if os.path.exists(ambuilder):
+            ambuilder = os.path.abspath(ambuilder)
+            libbuilders = SdkLibBuilder(sdk, name, cxx)
+            context.Build(os.path.relpath(ambuilder, context.sourcePath), { 'HL2SDK': libbuilders })
+            if len(libbuilders.libs) != 1:
+                raise Exception('No lib found for {0}'.format(name))
+            return libbuilders.libs[0]
+        return None
 
 class SdkHelpers(object):
     def __init__(self):
@@ -46,14 +96,7 @@ class SdkHelpers(object):
 
             for cxx in cxx_list:
                 if SdkHelpers.shouldBuildSdk(sdk, cxx):
-                    protoc = None
-                    rel_protoc_path = sdk[cxx.target.platform].get('protoc_path', None)
-                    if rel_protoc_path:
-                        protoc_path = os.path.join(sdk['path'], rel_protoc_path)
-                        protoc = builder.DetectProtoc(path = protoc_path)
-                        for path in sdk['include_paths']:
-                            protoc.includes += [os.path.join(sdk['path'], path)]
-                    self.sdk_targets += [SdkTarget(sdk, cxx, protoc)]
+                    self.sdk_targets += [SdkTarget(builder, sdk, cxx)]
 
         if 'present' in sdk_list:
             for sdk in not_found:
@@ -139,12 +182,22 @@ class SdkHelpers(object):
         return out
 
     @staticmethod
-    def configureCxx(context, binary, sdk):
-        cxx = binary.compiler
+    def addLibrary(context, binary, sdk, name):
+        ambuilder = os.path.join(sdk['path'], name, 'AMBuilder')
+        if os.path.exists(ambuilder):
+            builder = SdkLibBuilder(sdk['name'], binary.compiler)
+            context.Build([ambuilder], { 'HL2SDK': builder })
+            if len(builder.libs) != 1:
+                raise Exception('No lib found for {0}'.format(name))
+            task = builder.libs[0]
+            binary.compiler.postlink += [os.path.join(context.buildPath, task.binary.path)]
+            binary.compiler.linkdeps += [task.binary]
 
+    @staticmethod
+    def configureCxx(context, cxx, sdk):
         # Includes/defines.
         cxx.defines += ['SOURCE_ENGINE={}'.format(sdk['code'])]
-        cxx.defines += ['GAME_DLL']
+        cxx.defines += ['GAME_DLL', 'RAD_TELEMETRY_DISABLED']
 
         if sdk['name'] in ['sdk2013', 'bms', 'pvkii', 'tf2', 'css', 'dods', 'hl2dm'] and cxx.like('gcc'):
             # The 2013 SDK already has these in public/tier0/basetypes.h
@@ -166,7 +219,7 @@ class SdkHelpers(object):
             if cxx.version >= 1900:
                 cxx.linkflags += ['legacy_stdio_definitions.lib']
         else:
-            cxx.defines += ['COMPILER_GCC']
+            cxx.defines += ['COMPILER_GCC', '_LINUX', 'LINUX', 'POSIX', 'GNUC']
 
         if cxx.target.arch == 'x86_64':
             cxx.defines += ['X64BITS', 'PLATFORM_64BITS']
@@ -180,6 +233,8 @@ class SdkHelpers(object):
         # Link steps.
         for lib in SdkHelpers.getLists(sdk, 'libs', cxx):
             cxx.linkflags += [os.path.join(sdk['path'], lib)]
+        for lib in SdkHelpers.getLists(sdk, 'dynamic_libs', cxx):
+            cxx.linkflags += [os.path.join(sdk['path'], lib)]
         for lib in SdkHelpers.getLists(sdk, 'postlink_libs', cxx):
             cxx.postlink += [os.path.join(sdk['path'], lib)]
 
@@ -189,35 +244,21 @@ class SdkHelpers(object):
 
         if cxx.target.platform == 'linux':
             cxx.linkflags[0:0] = ['-lm']
-        elif cxx.target.platform == 'mac':
-            cxx.linkflags.append('-liconv')
-
-        dynamic_libs = SdkHelpers.getLists(sdk, 'dynamic_libs', cxx)
-        for library in dynamic_libs:
-            file_name = os.path.split(library)[1]
-            source_path = os.path.join(sdk['path'], library)
-            output_path = os.path.join(binary.localFolder, file_name)
-
-            context.AddFolder(binary.localFolder)
-            output = context.AddSymlink(source_path, output_path)
-
-            cxx.weaklinkdeps += [output]
-            cxx.linkflags[0:0] = [file_name]
 
         if cxx.target.platform == 'linux':
             if sdk[cxx.target.platform]['uses_system_cxxlib']:
                 cxx.linkflags.remove('-static-libstdc++')
                 cxx.linkflags += ['-lstdc++']
-        elif cxx.target.platform == 'mac':
-            if sdk[cxx.target.platform]['cxxlib'] == 'stdc++':
-                # Switch libc++ to libstdc++ for protobuf linkage.
-                cxx.cxxflags.remove('-stdlib=libc++')
-                cxx.linkflags.remove('-stdlib=libc++')
-                cxx.linkflags.remove('-lc++')
 
-                cxx.cxxflags += ['-stdlib=libstdc++']
-                cxx.linkflags += ['-stdlib=libstdc++']
-                cxx.linkflags += ['-lstdc++']
+        if 'tier1' in sdk and cxx.target.arch in sdk['tier1']:
+            task = sdk['tier1'][cxx.target.arch]
+            cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
+            cxx.linkdeps += [task.binary]
+
+        if 'mathlib' in sdk and cxx.target.arch in sdk['mathlib']:
+            task = sdk['mathlib'][cxx.target.arch]
+            cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
+            cxx.linkdeps += [task.binary]
 
 
 rvalue = SdkHelpers()

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -257,13 +257,15 @@ class SdkHelpers(object):
 
         if 'tier1' in sdk and cxx.target.arch in sdk['tier1']:
             task = sdk['tier1'][cxx.target.arch]
-            cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
-            cxx.linkdeps += [task.binary]
+            if task != None:
+                cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
+                cxx.linkdeps += [task.binary]
 
         if 'mathlib' in sdk and cxx.target.arch in sdk['mathlib']:
             task = sdk['mathlib'][cxx.target.arch]
-            cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
-            cxx.linkdeps += [task.binary]
+            if task != None:
+                cxx.postlink += [os.path.join(context.buildPath, task.binary.path)]
+                cxx.linkdeps += [task.binary]
 
 
 rvalue = SdkHelpers()

--- a/SdkHelpers.ambuild
+++ b/SdkHelpers.ambuild
@@ -29,9 +29,9 @@ class SdkTarget(object):
         rel_protoc_path = sdk[cxx.target.platform].get('protoc_path', None)
         if rel_protoc_path:
             protoc_path = os.path.join(sdk['path'], rel_protoc_path)
-            self.protoc = builder.DetectProtoc(path = protoc_path)
+            self.protoc = context.DetectProtoc(path = protoc_path)
             for path in sdk['include_paths']:
-                protoc.includes += [os.path.join(sdk['path'], path)]
+                self.protoc.includes += [os.path.join(sdk['path'], path)]
         # Find tier1
         tier1 = SdkTarget.findLibrary(context, sdk, cxx, 'tier1')
         # Find mathlib

--- a/manifests/css.json
+++ b/manifests/css.json
@@ -35,12 +35,21 @@
             "NO_HOOK_MALLOC",
             "NO_MALLOC_OVERRIDE"
         ],
+        "cflags": [
+            "-Wno-overloaded-virtual",
+            "-Wno-unused-function",
+            "-Wno-unknown-pragmas",
+            "-Wno-dangling-else",
+            "-Wno-unused-variable",
+            "-Wno-unused-private-field",
+            "-Wno-inconsistent-missing-override",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-tautological-constant-out-of-range-compare",
+            "-Wno-undefined-bool-conversion",
+            "-fPIC"
+        ],
         "x86": {
             "cflags": ["-march=pentium4", "-march=core2", "-msse2", "-mfpmath=sse"],
-            "postlink_libs": [
-                "lib/public/linux/mathlib_i486.a",
-                "lib/public/linux/tier1_i486.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux/libtier0_srv.so",
                 "lib/public/linux/libvstdlib_srv.so"
@@ -48,10 +57,6 @@
         },
         "x86_64": {
             "cflags": ["-march=nocona", "-march=core2"],
-            "postlink_libs": [
-                "lib/public/linux64/mathlib.a",
-                "lib/public/linux64/tier1.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux64/libtier0_srv.so",
                 "lib/public/linux64/libvstdlib_srv.so"
@@ -62,16 +67,12 @@
     "windows": {
         "x86": {
             "libs": [
-                "lib/public/x86/mathlib.lib",
                 "lib/public/x86/tier0.lib",
-                "lib/public/x86/tier1.lib",
                 "lib/public/x86/vstdlib.lib"
             ]
         },
         "x86_64": {
             "libs": [
-                "lib/public/x64/mathlib.lib",
-                "lib/public/x64/tier1.lib",
                 "lib/public/x64/tier0.lib",
                 "lib/public/x64/vstdlib.lib"
             ]

--- a/manifests/dods.json
+++ b/manifests/dods.json
@@ -35,12 +35,21 @@
             "NO_HOOK_MALLOC",
             "NO_MALLOC_OVERRIDE"
         ],
+        "cflags": [
+            "-Wno-overloaded-virtual",
+            "-Wno-unused-function",
+            "-Wno-unknown-pragmas",
+            "-Wno-dangling-else",
+            "-Wno-unused-variable",
+            "-Wno-unused-private-field",
+            "-Wno-inconsistent-missing-override",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-tautological-constant-out-of-range-compare",
+            "-Wno-undefined-bool-conversion",
+            "-fPIC"
+        ],
         "x86": {
             "cflags": ["-march=pentium4", "-march=core2", "-msse2", "-mfpmath=sse"],
-            "postlink_libs": [
-                "lib/public/linux/mathlib_i486.a",
-                "lib/public/linux/tier1_i486.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux/libtier0_srv.so",
                 "lib/public/linux/libvstdlib_srv.so"
@@ -48,10 +57,6 @@
         },
         "x86_64": {
             "cflags": ["-march=nocona", "-march=core2"],
-            "postlink_libs": [
-                "lib/public/linux64/mathlib.a",
-                "lib/public/linux64/tier1.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux64/libtier0_srv.so",
                 "lib/public/linux64/libvstdlib_srv.so"
@@ -62,16 +67,12 @@
     "windows": {
         "x86": {
             "libs": [
-                "lib/public/x86/mathlib.lib",
                 "lib/public/x86/tier0.lib",
-                "lib/public/x86/tier1.lib",
                 "lib/public/x86/vstdlib.lib"
             ]
         },
         "x86_64": {
             "libs": [
-                "lib/public/x64/mathlib.lib",
-                "lib/public/x64/tier1.lib",
                 "lib/public/x64/tier0.lib",
                 "lib/public/x64/vstdlib.lib"
             ]

--- a/manifests/hl2dm.json
+++ b/manifests/hl2dm.json
@@ -35,12 +35,21 @@
             "NO_HOOK_MALLOC",
             "NO_MALLOC_OVERRIDE"
         ],
+        "cflags": [
+            "-Wno-overloaded-virtual",
+            "-Wno-unused-function",
+            "-Wno-unknown-pragmas",
+            "-Wno-dangling-else",
+            "-Wno-unused-variable",
+            "-Wno-unused-private-field",
+            "-Wno-inconsistent-missing-override",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-tautological-constant-out-of-range-compare",
+            "-Wno-undefined-bool-conversion",
+            "-fPIC"
+        ],
         "x86": {
             "cflags": ["-march=pentium4", "-march=core2", "-msse2", "-mfpmath=sse"],
-            "postlink_libs": [
-                "lib/public/linux/mathlib_i486.a",
-                "lib/public/linux/tier1_i486.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux/libtier0_srv.so",
                 "lib/public/linux/libvstdlib_srv.so"
@@ -48,10 +57,6 @@
         },
         "x86_64": {
             "cflags": ["-march=nocona", "-march=core2"],
-            "postlink_libs": [
-                "lib/public/linux64/mathlib.a",
-                "lib/public/linux64/tier1.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux64/libtier0_srv.so",
                 "lib/public/linux64/libvstdlib_srv.so"
@@ -62,16 +67,12 @@
     "windows": {
         "x86": {
             "libs": [
-                "lib/public/x86/mathlib.lib",
                 "lib/public/x86/tier0.lib",
-                "lib/public/x86/tier1.lib",
                 "lib/public/x86/vstdlib.lib"
             ]
         },
         "x86_64": {
             "libs": [
-                "lib/public/x64/mathlib.lib",
-                "lib/public/x64/tier1.lib",
                 "lib/public/x64/tier0.lib",
                 "lib/public/x64/vstdlib.lib"
             ]

--- a/manifests/tf2.json
+++ b/manifests/tf2.json
@@ -35,12 +35,21 @@
             "NO_HOOK_MALLOC",
             "NO_MALLOC_OVERRIDE"
         ],
+        "cflags": [
+            "-Wno-overloaded-virtual",
+            "-Wno-unused-function",
+            "-Wno-unknown-pragmas",
+            "-Wno-dangling-else",
+            "-Wno-unused-variable",
+            "-Wno-unused-private-field",
+            "-Wno-inconsistent-missing-override",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-tautological-constant-out-of-range-compare",
+            "-Wno-undefined-bool-conversion",
+            "-fPIC"
+        ],
         "x86": {
             "cflags": ["-march=pentium4", "-march=core2", "-msse2", "-mfpmath=sse"],
-            "postlink_libs": [
-                "lib/public/linux/mathlib_i486.a",
-                "lib/public/linux/tier1_i486.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux/libtier0_srv.so",
                 "lib/public/linux/libvstdlib_srv.so"
@@ -48,10 +57,6 @@
         },
         "x86_64": {
             "cflags": ["-march=nocona", "-march=core2"],
-            "postlink_libs": [
-                "lib/public/linux64/mathlib.a",
-                "lib/public/linux64/tier1.a"
-            ],
             "dynamic_libs": [
                 "lib/public/linux64/libtier0_srv.so",
                 "lib/public/linux64/libvstdlib_srv.so"
@@ -62,16 +67,12 @@
     "windows": {
         "x86": {
             "libs": [
-                "lib/public/x86/mathlib.lib",
                 "lib/public/x86/tier0.lib",
-                "lib/public/x86/tier1.lib",
                 "lib/public/x86/vstdlib.lib"
             ]
         },
         "x86_64": {
             "libs": [
-                "lib/public/x64/mathlib.lib",
-                "lib/public/x64/tier1.lib",
                 "lib/public/x64/tier0.lib",
                 "lib/public/x64/vstdlib.lib"
             ]


### PR DESCRIPTION
Instead of linking to arbitrary builds of tier1 & mathlib (which have caused problems), integrate the compilation of tier1 & mathlib into the ambuild script.

As of today I've only added the necessary buildscripts for tier1 & mathlib on the tf2/css/dods/hl2dm branches, however it should be fairly trivial to add the same for the rest (if that becomes desired). 