### PR TITLE
Remove tier1.lib/a usage from CS2 & Dota

### DIFF
--- a/manifests/cs2.json
+++ b/manifests/cs2.json
@@ -30,7 +30,6 @@
         "x86_64": {
             "postlink_libs": [
                 "lib/linux64/mathlib.a",
-                "lib/linux64/tier1.a",
                 "lib/linux64/interfaces.a",
                 "lib/linux64/release/libprotobuf.a"
             ],
@@ -50,7 +49,6 @@
                 "lib/public/win64/2015/libprotobuf.lib",
                 "lib/public/win64/mathlib.lib",
                 "lib/public/win64/tier0.lib",
-                "lib/public/win64/tier1.lib",
                 "lib/public/win64/interfaces.lib"
             ]
         },

--- a/manifests/dota.json
+++ b/manifests/dota.json
@@ -30,7 +30,6 @@
         "x86_64": {
             "postlink_libs": [
                 "lib/linux64/mathlib.a",
-                "lib/linux64/tier1.a",
                 "lib/linux64/interfaces.a",
                 "lib/linux64/release/libprotobuf.a"
             ],
@@ -50,7 +49,6 @@
                 "lib/public/win64/2015/libprotobuf.lib",
                 "lib/public/win64/mathlib.lib",
                 "lib/public/win64/tier0.lib",
-                "lib/public/win64/tier1.lib",
                 "lib/public/win64/interfaces.lib"
             ]
         },


### PR DESCRIPTION
Due to recent changes in hl2sdk-cs2/dota, tier1.lib/.a is obsoleted now, this pr reflects these changes.

Metamod would also need a hl2sdk-manifests bump when this lands.